### PR TITLE
[sc-139630][sc-138862]:Update to android 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@movable/cordova-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MovableInk Cordova SDK",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/src/android/app.gradle
+++ b/src/android/app.gradle
@@ -4,6 +4,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.movableink.sdk:inked:1.6.0")
+    implementation("com.movableink.sdk:inked:1.6.1")
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.20'
 }


### PR DESCRIPTION
update android version to 1.6.1 fixes :
[sc-13963](https://app.shortcut.com/movableink/story/139630/vueling-sdk-crashes-android)
[sc-138862](https://app.shortcut.com/movableink/story/138862/android-error-when-surfacing-in-app-messages-using-sdk)